### PR TITLE
Remove dependency on ORM for Subscriber

### DIFF
--- a/DependencyInjection/OneupAclExtension.php
+++ b/DependencyInjection/OneupAclExtension.php
@@ -18,18 +18,15 @@ class OneupAclExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('security.xml');
         $loader->load('driver.xml');
-
-        // if doctrine/orm is available, load orm configuration
-        if (class_exists('Doctrine\ORM\EntityManager')) {
-            $loader->load('orm.xml');
-        }
+        $loader->load('doctrine.xml');
 
         if (class_exists('Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle')) {
             $loader->load('configuration.xml');
         }
 
         $strategy = constant(
-            sprintf('Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy::%s',
+            sprintf(
+                'Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy::%s',
                 strtoupper($config['permission_strategy'])
             )
         );

--- a/EventListener/DoctrineSubscriber.php
+++ b/EventListener/DoctrineSubscriber.php
@@ -3,7 +3,7 @@
 namespace Oneup\AclBundle\EventListener;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class DoctrineSubscriber implements EventSubscriber
@@ -20,7 +20,7 @@ class DoctrineSubscriber implements EventSubscriber
         $chain = $this->container->get('oneup_acl.driver_chain');
         $manager = $this->container->get('oneup_acl.manager');
 
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
         $object = new \ReflectionClass($entity);
 
         $metaData = $chain->readMetaData($object);
@@ -48,7 +48,7 @@ class DoctrineSubscriber implements EventSubscriber
             return;
         }
 
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
         $object = new \ReflectionClass($entity);
 
         $metaData = $chain->readMetaData($object);

--- a/Resources/config/doctrine.xml
+++ b/Resources/config/doctrine.xml
@@ -8,6 +8,7 @@
         <service id="oneup_acl.doctrine_subscriber" class="Oneup\AclBundle\EventListener\DoctrineSubscriber">
             <argument type="service" id="service_container" />
             <tag name="doctrine.event_subscriber" />
+            <tag name="doctrine_mongodb.odm.event_subscriber" />
         </service>
     </services>
 </container>

--- a/Tests/EventListener/DoctrineSubscriberTest.php
+++ b/Tests/EventListener/DoctrineSubscriberTest.php
@@ -26,13 +26,13 @@ class DoctrineSubscriberTest extends AbstractSecurityTest
         $this->assertFalse($this->manager->isGranted('VIEW', $object));
         $this->assertFalse($this->manager->isGranted('EDIT', $object));
 
-        $args = $this->getMockBuilder('Doctrine\ORM\Event\LifecycleEventArgs')
+        $args = $this->getMockBuilder('Doctrine\Common\Persistence\Event\LifecycleEventArgs')
             ->disableOriginalConstructor()
             ->getMock()
         ;
 
         $args->expects($this->any())
-            ->method('getEntity')
+            ->method('getObject')
             ->will($this->returnValue($object))
         ;
 
@@ -58,13 +58,13 @@ class DoctrineSubscriberTest extends AbstractSecurityTest
         $this->assertTrue($this->manager->isGranted('VIEW', $object, 'foo'));
         $this->assertTrue($this->manager->isGranted('EDIT', $object, 'bar'));
 
-        $args = $this->getMockBuilder('Doctrine\ORM\Event\LifecycleEventArgs')
+        $args = $this->getMockBuilder('Doctrine\Common\Persistence\Event\LifecycleEventArgs')
             ->disableOriginalConstructor()
             ->getMock()
         ;
 
         $args->expects($this->any())
-            ->method('getEntity')
+            ->method('getObject')
             ->will($this->returnValue($object))
         ;
 


### PR DESCRIPTION
By using the common doctrine EventClass it is possible to use the subscriber for
other database systems.
Adapted service config to also work with mongoDB
