### PR TITLE
Allow removing of acl entries also if no annotation used

### DIFF
--- a/EventListener/DoctrineSubscriber.php
+++ b/EventListener/DoctrineSubscriber.php
@@ -44,10 +44,6 @@ class DoctrineSubscriber implements EventSubscriber
         $manager = $this->container->get('oneup_acl.manager');
         $remove = $this->container->getParameter('oneup_acl.remove_orphans');
 
-        if (!$remove) {
-            return;
-        }
-
         $entity = $args->getEntity();
         $object = new \ReflectionClass($entity);
 


### PR DESCRIPTION
I'm not sure what is the exact reason to not remove acl entries if you are not using @DomainObject annotation.

Maybe there is a reason, but I don't see it currently.

I think a good solution is to allow different scenarios:
- config_remove = true, no annotation -> delete
- config_remove = true, annotation(remove=true) -> delete
- config_remove = true, annotation(remove=false) -> NO delete
- config_remove = false, no annotation -> NO delete
- config_remove = false, annotation(remove=true) -> delete
- config_remove = false, annotation(remove=false) -> NO delete

What do you think?
