### PR TITLE
Fix bug for MongoDb Odb bundle 1.0.0-beta9

### DIFF
--- a/EventListener/DoctrineSubscriber.php
+++ b/EventListener/DoctrineSubscriber.php
@@ -20,7 +20,11 @@ class DoctrineSubscriber implements EventSubscriber
         $chain = $this->container->get('oneup_acl.driver_chain');
         $manager = $this->container->get('oneup_acl.manager');
 
-        $entity = $args->getObject();
+        if ($args instanceof \Doctrine\ODM\MongoDB\Event\LifecycleEventArgs) {
+            $entity = $args->getDocument();
+        } else {
+            $entity = $args->getObject();
+        }
         $object = new \ReflectionClass($entity);
 
         $metaData = $chain->readMetaData($object);


### PR DESCRIPTION
On Mongodb ODB bundle 1.0.0-BETA9, the lifecycle event does not have a
`getObject` method (because it does not extends Doctrine\Common\Persistence\Event\LifecycleEventArgs)

See [the 1.0.0 file](https://github.com/doctrine/mongodb-odm/blob/1.0.0-BETA9/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php) and the [master version](https://github.com/doctrine/mongodb-odm/blob/master/lib/Doctrine/ODM/MongoDB/Event/LifecycleEventArgs.php)

When the next version is released you can revert this commit and use the
LifecycleEventArgs as an argument
