### PR TITLE
Access all objects for a specific user

### DIFF
--- a/DependencyInjection/OneupAclExtension.php
+++ b/DependencyInjection/OneupAclExtension.php
@@ -16,6 +16,7 @@ class OneupAclExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
         $loader->load('security.xml');
         $loader->load('driver.xml');
         $loader->load('doctrine.xml');

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="security.acl.dbal.provider.class">Oneup\AclBundle\Security\Authorization\Acl\AclProvider</parameter>
+    </parameters>
+</container>

--- a/Resources/doc/find_objects_for_user.md
+++ b/Resources/doc/find_objects_for_user.md
@@ -1,0 +1,23 @@
+Access all objects for a specific user
+===========================
+
+For the moment, Symfony does not provide a good way to access all the registered objects for a user.\
+They recommend to fetch all your objects, and test them one by one.
+
+This can easily become a pain if you have a lot of items to load.
+
+This bundle adds the reverse side to symfony: you can load all items for a user just with this command: 
+
+```php
+$aclProvider = $this->get('security.acl.provider');
+$user = $this->get('security.context')->getToken()->getUser();
+
+$class = 'Acme\DemoBundle\Entity\MyEntity';
+$objectIdentities = $aclProvider->findObjectIdentitiesForUser($user, MaskBuilder::MASK_EDIT, $class);
+foreach ($objectIdentities as $objectIdentity) {
+    $id = $objectIdentity->getIdentifier(); // this is your database primary key
+    $item = ... // fetch your object by id (doctrine, mongodb, propel, elasticsearch, etc.)
+}
+```
+
+> Credit to: Phoenix Zerin and his [thread](http://stackoverflow.com/questions/20154865/find-aces-by-securityidentity-instead-of-objectidentity) on StackOverflow.

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -82,5 +82,6 @@ features.
 * [Define class permissions via annotations](annotation.md)
 * [Configure auto removal of Acl entries](removal.md)
 * [Preload Acl to a CollectionCache](cache.md)
+* [Access all objects for a specific user](find_objects_for_user.md)
 * [Configuration reference](configuration_reference.md)
 * [Testing the bundle](testing.md)

--- a/Security/Authorization/Acl/AclProvider.php
+++ b/Security/Authorization/Acl/AclProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Oneup\AclBundle\Security\Authorization\Acl;
+
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\RoleInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Symfony\Component\Security\Acl\Dbal\MutableAclProvider;
+use Symfony\Component\Security\Acl\Permission\MaskBuilder;
+
+/**
+ * AclProvider
+ * This class is "inspired" by this post:
+ * http://stackoverflow.com/questions/20154865/find-aces-by-securityidentity-instead-of-objectidentity
+ *
+ * @uses MutableAclProvider
+ */
+class AclProvider extends MutableAclProvider
+{
+    protected $connection;
+
+    /** Locates all objects that the specified User has access to.
+     *
+     * Note that this method has a few limitations:
+     *  - No support for filtering by mask.
+     *  - No support for ACEs that match one of the User's roles (only ACEs that
+     *      reference the User's security identity will be matched).
+     *  - Every ACE that matches is assumed to grant access.
+     *
+     * @param UserInterface $user
+     * @param string        $type   If set, filter by object type (classname).
+     *
+     * @return ObjectIdentity[]
+     */
+    public function findObjectIdentitiesForUser(
+        $identityObject,
+        $mask = MaskBuilder::MASK_VIEW,
+        $type = null
+    ) {
+        $securityIdentity = $this->getSecurityEntity($identityObject);
+        if (!$securityIdentity) {
+            return null;
+        }
+
+        $identifier = sprintf(
+            '%s-%s',
+            $securityIdentity->getClass(),
+            $securityIdentity->getUsername()
+        );
+
+        $sql = <<<END
+            SELECT
+              o.object_identifier
+            , c.class_type
+            FROM {$this->options['sid_table_name']} s
+            LEFT JOIN {$this->options['entry_table_name']} e
+                ON (
+                        (e.security_identity_id = s.id)
+                    or  {$this->connection->getDatabasePlatform()->getIsNullExpression('e.security_identity_id')}
+                )
+            LEFT JOIN {$this->options['oid_table_name']} o
+                ON (o.id = e.object_identity_id)
+            LEFT JOIN {$this->options['class_table_name']} c
+                ON (c.id = o.class_id)
+            WHERE s.identifier = {$this->connection->quote($identifier)}
+            AND e.mask > {$mask}
+END;
+
+        if ($type) {
+            $sql .= <<<END
+        AND c.class_type = {$this->connection->quote($type)}
+END;
+        }
+
+        $objectIdentities = array();
+
+        /* It would be awesome if we could use hydrateObjectIdentities()
+         * here.  Then we could do super fancy stuff like filter by mask and
+         * check whether ACEs grant or deny access.
+         *
+         * Unfortunately, that method is not accessible to subclasses.
+         */
+        $results = $this->connection->executeQuery($sql)->fetchAll();
+        foreach ($results as $row) {
+            $objectIdentities[] = new ObjectIdentity(
+                $row['object_identifier'],
+                $row['class_type']
+            );
+        }
+
+        return $objectIdentities;
+    }
+
+    /**
+     * getSecurityEntity
+     *
+     * @param mixed $identityObject
+     * @access private
+     * @return SecurityIdentity
+     */
+    private function getSecurityEntity($identityObject)
+    {
+        if ($identityObject instanceof UserInterface) {
+            return UserSecurityIdentity::fromAccount($identityObject);
+        } elseif ($identityObject instanceof TokenInterface) {
+            return UserSecurityIdentity::fromToken($identityObject);
+        }
+
+        return null;
+    }
+}

--- a/Tests/Model/SomeOtherObject.php
+++ b/Tests/Model/SomeOtherObject.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Oneup\AclBundle\Tests\Model;
+
+use Oneup\AclBundle\Mapping\Annotation\DomainObject;
+use Oneup\AclBundle\Mapping\Annotation\ClassPermission;
+use Oneup\AclBundle\Mapping\Annotation\PropertyPermission;
+
+/**
+ * Masks from Symfony\Component\Security\Acl\Permission\MaskBuilder
+ *
+ * @DomainObject(remove=true, {
+ *   @ClassPermission({ "ROLE_USER" = 1 })
+ * })
+ */
+class SomeOtherObject
+{
+    private $id;
+    private $foo;
+    private $bar;
+
+    /**
+     * @PropertyPermission({ "ROLE_ADMIN" = 512 })
+     */
+    private $secured;
+
+    public function __construct($id, $foo = null, $bar = null)
+    {
+        $this->id = $id;
+        $this->foo = $foo;
+        $this->bar = $bar;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}

--- a/Tests/Security/Authorization/Acl/AclProviderTest.php
+++ b/Tests/Security/Authorization/Acl/AclProviderTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Oneup\AclBundle\Tests\Security\Authorization\Acl;
+
+use Symfony\Component\Security\Acl\Permission\MaskBuilder;
+use Symfony\Component\Security\Core\User\User;
+use Oneup\AclBundle\Tests\Model\SomeOtherObject;
+
+use Oneup\AclBundle\Tests\Model\AbstractSecurityTest;
+
+/**
+ * AclProviderTest
+ *
+ * @uses AbstractSecurityTest
+ * @author Julien Deniau <julien.deniau@mapado.com>
+ */
+class AclProviderTest extends AbstractSecurityTest
+{
+
+    /**
+     * testFindObjectIdentitiesForToken
+     *
+     * @access public
+     * @return void
+     */
+    public function testFindObjectIdentitiesForToken()
+    {
+        $aclProvider = $this->container->get('security.acl.provider');
+        $this->assertInstanceOf('Oneup\AclBundle\Security\Authorization\Acl\AclProvider', $aclProvider);
+
+        // empty object identity
+        $ret = $aclProvider->findObjectIdentitiesForUser(
+            $this->token,
+            MaskBuilder::MASK_VIEW
+        );
+        $this->assertEmpty($ret);
+
+        // add one
+        $this->manager->addObjectPermission($this->object1, $this->mask1, $this->token);
+        $ret = $aclProvider->findObjectIdentitiesForUser(
+            $this->token,
+            MaskBuilder::MASK_VIEW
+        );
+
+        $this->assertCount(1, $ret);
+
+        // add another one
+        $this->manager->addObjectPermission($this->object2, $this->mask1, $this->token);
+        $ret = $aclProvider->findObjectIdentitiesForUser(
+            $this->token,
+            MaskBuilder::MASK_VIEW
+        );
+
+        $this->assertCount(2, $ret);
+
+        $ret = $aclProvider->findObjectIdentitiesForUser(
+            $this->token,
+            MaskBuilder::MASK_DELETE
+        );
+        $this->assertEmpty($ret);
+    }
+
+    /**
+     * testFindObjectIdentitiesForUser
+     *
+     * @access public
+     * @return void
+     */
+    public function testFindObjectIdentitiesForUser()
+    {
+        $aclProvider = $this->container->get('security.acl.provider');
+        $user = new User('usertest', 'pwd');
+
+        $ret = $aclProvider->findObjectIdentitiesForUser(
+            $user,
+            MaskBuilder::MASK_EDIT
+        );
+        $this->assertEmpty($ret);
+
+        // add right on object2 (instanceof SomeObject)
+        $this->manager->addObjectPermission($this->object2, $this->mask1, $user);
+        $ret = $aclProvider->findObjectIdentitiesForUser($user, MaskBuilder::MASK_EDIT);
+        $this->assertCount(1, $ret);
+
+        // add another object type
+        $tmp = new SomeOtherObject(1);
+        $this->manager->addObjectPermission($tmp, $this->mask1, $user);
+        $ret = $aclProvider->findObjectIdentitiesForUser($user, MaskBuilder::MASK_EDIT);
+        $this->assertCount(2, $ret);
+
+        // filter by type
+        $ret = $aclProvider->findObjectIdentitiesForUser($user, MaskBuilder::MASK_EDIT, get_class($tmp));
+        $this->assertCount(1, $ret);
+    }
+}


### PR DESCRIPTION
This commit is the first half of the issue discussed [here](https://github.com/1up-lab/OneupAclBundle/issues/11).
It adds the `findObjectIdentitiesForUser` method.

As requested I added some test, and added the `TokenInterface` support, but did not add the `RoleInterface` support because I don't think a Role can be have ACL on objects, but correct me if I am wrong. If so, the RoleInterface does not provides a `getClass()` nor a `getUsername()` method.
