### PR TITLE
the > operator must be >=

### DIFF
--- a/Security/Authorization/Acl/AclProvider.php
+++ b/Security/Authorization/Acl/AclProvider.php
@@ -66,7 +66,7 @@ class AclProvider extends MutableAclProvider
             LEFT JOIN {$this->options['class_table_name']} c
                 ON (c.id = o.class_id)
             WHERE s.identifier = {$this->connection->quote($identifier)}
-            AND e.mask > {$mask}
+            AND e.mask >= {$mask}
 END;
 
         if ($type) {


### PR DESCRIPTION
Actually, it filtered the wanted mask too.
Ex: 
`MASK_VIEW = 1`
`e.mask > 1` will exclude MASK_VIEW and show only MASK > MASK_VIEW
