### PR TITLE
remove useless import

### DIFF
--- a/Security/Acl/Model/AbstractAclManager.php
+++ b/Security/Acl/Model/AbstractAclManager.php
@@ -13,8 +13,6 @@ use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Doctrine\Common\Util\ClassUtils;
 
-use Oneup\AclBundle\Security\Acl\Model\AclManagerInterface;
-
 abstract class AbstractAclManager implements AclManagerInterface
 {
     abstract protected function getProvider();


### PR DESCRIPTION
As the namespace is `Oneup\AclBundle\Security\Acl\Model`, you do not need to import the interface. It will look in the current namespace first.
